### PR TITLE
Improve event loops

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,19 @@ const FAST_SPEED:   Duration = Duration::from_millis(50);
 const FONT_FILE : &str = "./res/Roboto-Regular.ttf";
 //const FONT_FILE = "/usr/share/fonts/truetype/roboto/unhinted/RobotoTTF/Roboto-Regular.ttf";
 
+
+/// Entry point
+fn main() {
+    let ttf_context = ttf::init().map_err(|e| e.to_string()).unwrap();
+    let mut game = Game::new(&ttf_context);
+    game.start();
+}
+
+
+/// A particular `Game` can be in any of these states. We can think of they as different
+/// screens in the game.
 #[derive(Debug)]
 enum GameState {
-    /// A particular `Game` can be in any of these states. We can thing of they as different
-    /// screens in the game.
     STARTING,
     PLAYING,
     PAUSED,
@@ -36,55 +45,66 @@ enum GameState {
 }
 
 
-#[derive(Debug)]
+/// In a given `GameState`, certain actions are possible. Those are denoted by these
+/// `GameTransition`s.
+#[derive(PartialEq, Debug)]
 enum GameTransition {
-    /// In a given `GameState`, certain actions are possible. Those are denoted by these
-    /// `GameTransition`s.
     PLAY,
     PAUSE,
-    LOOSE,
+    LOSE,
     EXIT,
 }
 
+
+/// The area through which the snake can move is composed of cells. The area has `hcells` width
+/// and `vcells` height.
 struct GameArea {
-    /// The area through which the snake can move is composed of cells. The area has `hcells` width
-    /// and `vcells` height.
     hcells      : u32,
     vcells      : u32,
     game_area   : Rect,
+    /// SDL `Rect`angles conforming the game grid:
     grid        : Vec<Rect>,
 }
 
+
+/// A `Snake` can move in any of these directions. Well, that actually depends on the current
+/// direction. E.g. if the `Snake` is moving `LEFT`, it cannot change its direction to `RIGHT`.
+#[derive(PartialEq)]
 enum Direction {
-    /// A `Snake` can move in any of these directions. Well, that actually depends on the current
-    /// direction. E.g. if the `Snake` is moving `LEFT`, it cannot change its direction to `RIGHT`.
     LEFT,
     RIGHT,
     UP,
     DOWN,
 }
 
+
+/// The coordinates of a cell in the game display.
 #[derive(Debug, Clone, Copy)]
 struct Coordinate {
     x           : u32,
     y           : u32
 }
 
+
+/// A `Snake` is essentially a vector of cells in the grid, whose head is moving in certain
+/// `direction`.
 struct Snake {
-    /// A `Snake` is essentially a vector of cells in the grid, whose head is moving in certain
-    /// `direction`.
     direction   :   Direction,
     body        :   Vec<Coordinate>,
 }
 
+
+/// We use the GameContext to stash anything related to the underlying SDL structures.
 struct GameContext {
-    /// We use the GameContext to stash anything related to the underlying SDL structures.
     current_state   : GameState,
     canvas          : Canvas<Window>,
     event_pump      : EventPump,
 }
 
+
 impl GameContext {
+
+    /// Constructor
     fn new() -> GameContext {
         let sdl_context = sdl2::init().unwrap();
         let video_subsystem = sdl_context.video().unwrap();
@@ -102,17 +122,18 @@ impl GameContext {
 
         let event_pump = sdl_context.event_pump().unwrap();
 
-       GameContext {
-           current_state : GameState::STARTING,
-           canvas        : canvas,
-           event_pump    : event_pump,
-       }
+        GameContext {
+            current_state : GameState::STARTING,
+            canvas        : canvas,
+            event_pump    : event_pump,
+        }
     }
-
 }
 
-/// Generates a `Rec`tangle whose units are in pixels.
-fn rec_generator(display: &GameArea, coord: &Coordinate) -> Option<Rect> {
+
+/// Generates the SDL `Rect`angle corresponding to the given game `coord`inate.
+/// The `Rect` must fit inside `GameArea`; otherwise `None` is returned.
+fn create_rect(display: &GameArea, coord: &Coordinate) -> Option<Rect> {
 
     if coord.x > display.hcells {
         return None;
@@ -129,6 +150,7 @@ fn rec_generator(display: &GameArea, coord: &Coordinate) -> Option<Rect> {
 
     return Some(r);
 }
+
 
 /// Create a `Snake` with a certain number of cells as its body. Let's always initialize its
 /// direction to `RIGHT` for now.
@@ -166,6 +188,7 @@ fn create_snake(display: &GameArea) -> Snake {
     return snake;
 }
 
+
 /// As explained earlier, GameArea is a grid of cells. Here we create such cells as rectangles.
 fn create_grid() -> GameArea {
     let mut display = GameArea {
@@ -180,7 +203,7 @@ fn create_grid() -> GameArea {
 
     for vcell in 0..display.vcells {
         for hcell in 0..display.hcells {
-            let r = rec_generator(&display, &Coordinate { x: hcell, y: vcell }).unwrap();
+            let r = create_rect(&display, &Coordinate { x: hcell, y: vcell }).unwrap();
             display.grid.push(r);
         }
     }
@@ -189,7 +212,8 @@ fn create_grid() -> GameArea {
 }
 
 
-struct Game {
+/// The actual state of the game.
+struct Game<'ttf> {
     context     : GameContext,
     // TODO: We need to figure out how to set the `lifetime`s of multiple structures. This one is
     // only an example. There are many more.
@@ -200,16 +224,22 @@ struct Game {
     food        : Coordinate,
 
     score_rect  : Rect,
+    font        : ttf::Font<'ttf, 'ttf>,
 }
 
-impl Game {
+
+impl<'ttf> Game<'ttf> {
     // TODO: Implement the appropriate screens for `STARTING` and `PAUSED` states.
 
     /// Create a new `Game`. Once a game is created, a game can be `start`ed(). As part of creating
     /// the `Game`, its `GameContext` is also initialized. Such initialization consists of setting
     /// up everything related to SDL2.
-    fn new() -> Game {
+    fn new(ttf_context: &'ttf ttf::Sdl2TtfContext) -> Game<'ttf> {
         let mut rng = rand::thread_rng();
+
+        let mut font = ttf_context.load_font(FONT_FILE, 24).expect("ERROR: Could not load font");
+        font.set_style(ttf::FontStyle::BOLD);
+
         let display = create_grid();
         let snake = create_snake(&display);
         let ctxt = GameContext::new();
@@ -229,12 +259,13 @@ impl Game {
             snake   : snake,
             food    : food,
             score_rect : score_rect,
+            font    : font,
         };
 
         return game;
     }
 
-    fn render_menu(&mut self, font: &ttf::Font, texture_creator: &render::TextureCreator<sdl2::video::WindowContext>, current_option: &mut u32) {
+    fn render_menu(&mut self, texture_creator: &render::TextureCreator<sdl2::video::WindowContext>, current_option: u32) {
         let options : Vec<&str> = vec![
             "  New Game",
             "> New Game",
@@ -242,10 +273,10 @@ impl Game {
             "> Exit",
         ];
 
-        let new_game_message = options[1 - *current_option as usize];
-        let (fw1, fh1) = font.size_of(new_game_message).unwrap();
+        let new_game_message = options[1 - current_option as usize];
+        let (fw1, fh1) = self.font.size_of(new_game_message).unwrap();
 
-        let new_game_surface  = font
+        let new_game_surface  = self.font
             .render(new_game_message)
             .solid(Color::RGB(0, 0, 0))
             .unwrap();
@@ -257,9 +288,9 @@ impl Game {
             .map_err(|e| e.to_string())
             .unwrap();
 
-        let exit_message = options[2 + *current_option as usize];
-        let (fw2, fh2) = font.size_of(exit_message).unwrap();
-        let exit_surface  = font
+        let exit_message = options[2 + current_option as usize];
+        let (fw2, fh2) = self.font.size_of(exit_message).unwrap();
+        let exit_surface  = self.font
             .render(exit_message)
             .solid(Color::RGB(0, 0, 0))
             .unwrap();
@@ -270,63 +301,54 @@ impl Game {
         self.context.canvas.copy(&exit_texture, None, Some(exit_rect))
             .map_err(|e| e.to_string())
             .unwrap();
-
     }
 
+
+    /// Draws the menu, highlighting the option indexed by `current_option`
+    fn draw_menu(&mut self, current_option: u32) {
+        // FIXME: Should `texture_creator` be a field?
+        let texture_creator = self.context.canvas.texture_creator();
+        self.context.canvas.set_draw_color(Color::RGB(255, 255, 255));
+        self.context.canvas.clear();
+        self.context.canvas.set_draw_color(Color::RGB(255, 0, 0));
+        self.context.canvas.draw_rect(self.display.game_area).unwrap();
+        self.render_menu(&texture_creator, current_option);
+        self.context.canvas.present();
+    }
+
+
+    /// Shows and manages the menu screen
     fn game_starting(&mut self) -> GameTransition {
 
-        let mut result : GameTransition = GameTransition::EXIT;
-
-        let texture_creator = self.context.canvas.texture_creator();
-
-        // TODO: `font` should be another field in `GameContext`. No need to load the font in every
-        // `GameState`. Fixing this requires knowledge on `Lifetimes`, though.
-        let ttf_context = ttf::init().map_err(|e| e.to_string()).unwrap();
-        let mut font = ttf_context.load_font(FONT_FILE, 24).expect("ERROR: Could not load font");
-        font.set_style(ttf::FontStyle::BOLD);
-
         let mut current_option : u32 = 0;
+        self.draw_menu(current_option);
 
-        'running: loop {
-            self.context.canvas.set_draw_color(Color::RGB(255, 255, 255));
-            self.context.canvas.clear();
+        loop {
+            let event = self.context.event_pump.wait_event();
+            match event {
+                Event::Quit{..} | Event::KeyDown { keycode: Some(Keycode::Escape), ..} => {
+                    return GameTransition::EXIT;
+                },
 
-            self.context.canvas.set_draw_color(Color::RGB(255, 0, 0));
-            self.context.canvas.draw_rect(self.display.game_area).unwrap();
+                Event::KeyDown { keycode: Some(Keycode::Up | Keycode::Down), ..} => {
+                    // Update menu:
+                    current_option = 1 - current_option;
+                    self.draw_menu(current_option);
+                },
 
-            for event in self.context.event_pump.poll_iter() {
-                match event {
-                    Event::Quit {..} |
-                    Event::KeyDown { keycode: Some(Keycode::Escape), ..} => {
-                        break 'running
-                    },
-                    Event::KeyDown { keycode: Some(Keycode::Up), ..} |
-                    Event::KeyDown { keycode: Some(Keycode::Down), ..} => {
-                        current_option = 1 - current_option;
-                    },
-                    Event::KeyDown { keycode: Some(Keycode::Return), ..} => {
-                        if current_option == 1 {
-                            result = GameTransition::EXIT;
-                            break 'running;
-                        }
-                        else {
-                            result = GameTransition::PLAY;
-                            break 'running;
-                        }
-                    },
-
-                    _ => {}
-                }
+                Event::KeyDown { keycode: Some(Keycode::Return), ..} => {
+                    if current_option == 1 {
+                        return GameTransition::EXIT;
+                    }
+                    else {
+                        return GameTransition::PLAY;
+                    }
+                },
+                _ => {}
             }
-
-            self.render_menu(&font, &texture_creator, &mut current_option);
-            self.context.canvas.present();
-            ::std::thread::sleep(self.speed);
-
         }
-
-        return result;
     }
+
 
     /// This is the loop for the `PLAYING` state. From this state we should be able to transition
     /// to either:
@@ -337,21 +359,13 @@ impl Game {
     /// 
     fn game_loop(&mut self) -> GameTransition {
 
-        let result : GameTransition;
         let mut rng = rand::thread_rng();
 
         let texture_creator = self.context.canvas.texture_creator();
         let mut score_surface : sdl2::surface::Surface;
         let mut texture : sdl2::render::Texture;
 
-        // TODO: `font` should be another field in `GameContext`. No need to load the font in every
-        // `GameState`. Fixing this requires knowledge on `Lifetimes`, though.
-        let ttf_context = ttf::init().map_err(|e| e.to_string()).unwrap();
-        let mut font = ttf_context.load_font(FONT_FILE, 24).expect("ERROR: Could not load font");
-        font.set_style(ttf::FontStyle::NORMAL);
-
-
-        'running: loop {
+        loop {
             self.context.canvas.set_draw_color(Color::RGB(255, 255, 255));
             self.context.canvas.clear();
 
@@ -367,31 +381,30 @@ impl Game {
                 match event {
                     Event::Quit {..} |
                     Event::KeyDown { keycode: Some(Keycode::Escape), ..} => {
-                        result = GameTransition::LOOSE;
-                        break 'running
+                        return GameTransition::LOSE;
                     },
-                    Event::KeyDown { keycode: Some(Keycode::Left), ..} => {
-                        match self.snake.direction {
-                            Direction::RIGHT {..}   => {},
-                            _                       => {self.snake.direction = Direction::LEFT;}
+                    Event::KeyDown { keycode: Some(Keycode::Left | Keycode::H), ..} =>
+                    {
+                        if self.snake.direction != Direction::RIGHT {
+                            self.snake.direction = Direction::LEFT;
                         }
                     },
-                    Event::KeyDown { keycode: Some(Keycode::Right), ..} => {
-                        match self.snake.direction {
-                            Direction::LEFT {..}    => {},
-                            _                       => {self.snake.direction = Direction::RIGHT;}
+                    Event::KeyDown { keycode: Some(Keycode::Right | Keycode::L), ..} =>
+                    {
+                        if self.snake.direction != Direction::LEFT {
+                            self.snake.direction = Direction::RIGHT;
                         }
                     },
-                    Event::KeyDown { keycode: Some(Keycode::Up), ..} => {
-                        match self.snake.direction {
-                            Direction::DOWN {..}    => {},
-                            _                       => {self.snake.direction = Direction::UP;}
+                    Event::KeyDown { keycode: Some(Keycode::Up | Keycode::K), ..} =>
+                    {
+                        if self.snake.direction != Direction::DOWN {
+                            self.snake.direction = Direction::UP;
                         }
                     },
-                    Event::KeyDown { keycode: Some(Keycode::Down), ..} => {
-                        match self.snake.direction {
-                            Direction::UP {..}      => {},
-                            _                       => {self.snake.direction = Direction::DOWN;}
+                    Event::KeyDown { keycode: Some(Keycode::Down | Keycode::J), ..} =>
+                    {
+                        if self.snake.direction != Direction::UP {
+                            self.snake.direction = Direction::DOWN;
                         }
                     },
                     Event::KeyDown { keycode: Some(Keycode::Return), ..} => {
@@ -411,32 +424,28 @@ impl Game {
             match self.snake.direction {
                 Direction::LEFT  {..} => { 
                     if new_head.x == 0 {
-                        result = GameTransition::LOOSE;
-                        break 'running;
+                        return GameTransition::LOSE;
                     }
 
                     new_head.x -= 1; 
                 },
                 Direction::RIGHT {..} => { 
                     if new_head.x == self.display.hcells - 1 {
-                        result = GameTransition::LOOSE;
-                        break 'running;
+                        return GameTransition::LOSE;
                     }
 
                     new_head.x += 1; 
                 },
                 Direction::UP    {..} => { 
                     if new_head.y == 0 {
-                        result = GameTransition::LOOSE;
-                        break 'running;
+                        return GameTransition::LOSE;
                     }
 
                     new_head.y -= 1; 
                 },
                 Direction::DOWN  {..} => { 
                     if new_head.y == self.display.vcells - 1 {
-                        result = GameTransition::LOOSE;
-                        break 'running;
+                        return GameTransition::LOSE;
                     }
 
                     new_head.y += 1; 
@@ -462,24 +471,23 @@ impl Game {
 
             for b in &self.snake.body[1..] {
                 if new_head.x == b.x && new_head.y == b.y {
-                    result = GameTransition::LOOSE;
-                    break 'running;
+                    return GameTransition::LOSE;
                 }
             }
 
 
             self.context.canvas.set_draw_color(Color::RGB(0,255,0));
-            self.context.canvas.fill_rect(rec_generator(&self.display, &self.snake.body[0])).unwrap();
+            self.context.canvas.fill_rect(create_rect(&self.display, &self.snake.body[0])).unwrap();
             self.context.canvas.set_draw_color(Color::RGB(0,0,255));
             for b in &self.snake.body[1..] {
-                self.context.canvas.fill_rect(rec_generator(&self.display, b)).unwrap();
+                self.context.canvas.fill_rect(create_rect(&self.display, b)).unwrap();
             }
 
             self.context.canvas.set_draw_color(Color::RGB(0,0,0));
-            self.context.canvas.fill_rect(rec_generator(&self.display, &self.food)).unwrap();
+            self.context.canvas.fill_rect(create_rect(&self.display, &self.food)).unwrap();
 
             let score_message = &format!("Score: {}", self.score);
-            score_surface  = font
+            score_surface  = self.font
                 .render(score_message)
                 .solid(Color::RGB(0, 0, 0))
                 .unwrap();
@@ -493,153 +501,119 @@ impl Game {
             self.context.canvas.present();
             ::std::thread::sleep(self.speed);
         }
-
-        return result;
     }
 
     /// This loop represents the `GAMEOVER` window that is shown when `GameState::PLAYING +
-    /// GameTransition::LOOSE` occurrs. 
+    /// GameTransition::LOSE` occurrs. 
     fn game_over_loop(&mut self) -> GameTransition {
-        let result : GameTransition;
+
+        self.context.canvas.set_draw_color(Color::RGB(255, 255, 255));
+        self.context.canvas.clear();
+
+        self.context.canvas.set_draw_color(Color::RGB(255, 0, 0));
+        self.context.canvas.draw_rect(self.display.game_area).unwrap();
 
         let texture_creator = self.context.canvas.texture_creator();
+        let new_game_message = "You lost! Press any key to continue...";
+        let (fw1, fh1) = self.font.size_of(new_game_message).unwrap();
 
-        // TODO: `font` should be another field in `GameContext`. No need to load the font in every
-        // `GameState`. Fixing this requires knowledge on `Lifetimes`, though.
-        let ttf_context = ttf::init().map_err(|e| e.to_string()).unwrap();
-        let mut font = ttf_context.load_font(FONT_FILE, 24).expect("ERROR: Could not load font");
-        font.set_style(ttf::FontStyle::BOLD);
+        let new_game_surface  = self.font
+            .render(new_game_message)
+            .solid(Color::RGB(0, 0, 0))
+            .unwrap();
+        let new_game_texture = texture_creator
+            .create_texture_from_surface(&new_game_surface)
+            .unwrap();
+        let new_game_rect = Rect::new(WIDTH as i32/2 - fw1 as i32/2, HEIGHT as i32/2 - fh1 as i32/2, fw1, fh1);
+        self.context.canvas.copy(&new_game_texture, None, Some(new_game_rect))
+            .map_err(|e| e.to_string())
+            .unwrap();
+        self.context.canvas.present();
 
-        'running: loop {
-            self.context.canvas.set_draw_color(Color::RGB(255, 255, 255));
-            self.context.canvas.clear();
-
-            self.context.canvas.set_draw_color(Color::RGB(255, 0, 0));
-            self.context.canvas.draw_rect(self.display.game_area).unwrap();
-
-            for event in self.context.event_pump.poll_iter() {
-                match event {
-                    Event::Quit {..} |
-                    Event::KeyDown { keycode: Some(Keycode::Escape), ..} => {
-                        result = GameTransition::EXIT;
-                        break 'running
-                    },
-                    Event::KeyDown {..}  => {
-                        result = GameTransition::PLAY;
-                        break 'running;
-                    },
-
-                    _ => {}
-                }
+        loop {
+            let event = self.context.event_pump.wait_event();
+            match event {
+                Event::Quit {..} | Event::KeyDown { keycode: Some(Keycode::Escape), ..} => {
+                    return GameTransition::EXIT;
+                },
+                Event::KeyDown {..}  => {
+                    return GameTransition::PLAY;
+                },
+                _ => {}
             }
-
-
-            let new_game_message = "You lost! Press any key to continue...";
-            let (fw1, fh1) = font.size_of(new_game_message).unwrap();
-
-            let new_game_surface  = font
-                .render(new_game_message)
-                .solid(Color::RGB(0, 0, 0))
-                .unwrap();
-            let new_game_texture = texture_creator
-                .create_texture_from_surface(&new_game_surface)
-                .unwrap();
-            let new_game_rect = Rect::new(WIDTH as i32/2 - fw1 as i32/2, HEIGHT as i32/2 - fh1 as i32/2, fw1, fh1);
-            self.context.canvas.copy(&new_game_texture, None, Some(new_game_rect))
-                .map_err(|e| e.to_string())
-                .unwrap();
-
-            self.context.canvas.present();
-            ::std::thread::sleep(self.speed);
-
         }
-
-        return result;
     }
 
     /// The `Game` is controlled by a `FSM`. This probably hasn't been fully thought through. Take
     /// it as a temporary skelleton for now. E.g. we currently don't have a `STARTING` window.
     /// TODO: Confirm that the FSM is complete.
     fn start(&mut self) {
-        'game: loop {
+        loop {
+            let transition;// = GameTransition::EXIT;
+            let mut handled = true; // Whether the transition was already processed by an inner state handle.
+            // Unless explicitly set to false in a state handle, we assume the transition was already processed.
+
             match self.context.current_state {
-                GameState::STARTING {..} => {
-                    let transition = self.game_starting();
-                    match transition {
-                        GameTransition::PLAY {..} => {
+
+                GameState::STARTING => {
+                    transition = self.game_starting();
+                    match transition
+                    {
+                        GameTransition::PLAY => {
                             self.context.current_state = GameState::PLAYING;
                         },
-
-                        GameTransition::EXIT {..} => {
-                            break 'game
-                        },
-
-                        _ => {
-                            panic!("Invalid transition {:?} in state {:?}", transition, self.context.current_state);
-                        }
+                        _ => { handled = false; }
                     }
                 },
 
-                GameState::PLAYING {..} => {
-                    let transition = self.game_loop();
-                    match transition {
-                        GameTransition::PAUSE {..} => {
+                GameState::PLAYING => {
+                    transition = self.game_loop();
+                    match transition
+                    {
+                        GameTransition::PAUSE => {
                             self.context.current_state = GameState::PAUSED;
                         },
-
-                        GameTransition::LOOSE {..} => {
+                        GameTransition::LOSE => {
                             self.context.current_state = GameState::GAMEOVER;
                         },
-
-                        _ => {
-                            panic!("Invalid transition {:?} in state {:?}", transition, self.context.current_state);
-                        }
+                        _ => { handled = false; }
                     }
-
                 },
 
-                GameState::PAUSED {..} => {
-                    let transition = GameTransition::PLAY;
-                    match transition {
-                        GameTransition::PLAY {..} => {
+                GameState::PAUSED => {
+                    transition = GameTransition::PLAY;
+                    match transition
+                    {
+                        GameTransition::PLAY => {
                             self.context.current_state = GameState::PLAYING;
                         },
-
-                        GameTransition::EXIT {..} => {
-                            break 'game
-                        },
-
-                        _ => {
-                            panic!("Invalid transition {:?} in state {:?}", transition, self.context.current_state);
-                        }
+                        _ => { handled = false; }
                     }
                 },
 
-                GameState::GAMEOVER {..} => {
-                    let transition = self.game_over_loop();
-                    match transition {
-                        GameTransition::PLAY {..} => {
+                GameState::GAMEOVER => {
+                    transition = self.game_over_loop();
+                    match transition
+                    {
+                        GameTransition::PLAY => {
                             self.context.current_state = GameState::STARTING;
                         },
-
-                        GameTransition::EXIT {..} => {
-                            break 'game
-                        },
-
-                        _ => {
-                            panic!("Invalid transition {:?} in state {:?}", transition, self.context.current_state);
-                        }
+                        _ => { handled = false; }
                     }
-                },
-            } // match current_state
-        } // end loop
+                }
+
+            }
+
+            if handled {
+                continue;
+            }
+            else if transition == GameTransition::EXIT {
+                // Global transition: finish game.
+                return;
+            }
+            else {
+                panic!("Invalid transition {:?} in state {:?}", transition, self.context.current_state);
+            }
+        }
     }
-}
-
-
-
-fn main() {
-
-    let mut game = Game::new();
-    game.start();
 }


### PR DESCRIPTION
- Simplify event matching
- Return transition objects directly from inner loop
- Use `event_pump.wait_event()` instead of `poll_iter()` when apropriate